### PR TITLE
feat: automatically add reviewers to proposals

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -80,7 +80,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}  
     - name: Jacob Heun
       uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
-      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      if: contains(fromJSON('["achingbrain","vasco-santos","dirkmc","rvagg","acruikshank","hannahhoward","gammazero","mvdan","willscott"]'), github.event.pull_request.user.login)
       with:
         reviewers: "jacobheun"
         token: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -1,0 +1,104 @@
+on:
+  pull_request:
+    types: [opened, reopened]
+name: Assign Reviewers
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Mikeal Rogers
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('["alanshaw", "olizilla", "gozala", "terichadbourne"]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "mikeal"
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Rod Vagg
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "rvagg"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Molly Mackinlay
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "momack2"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Alex North
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "anorth"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Pooja Shah
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "pooja"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Oli Evans
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "olizilla"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Steve Loeppky
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "BigLep"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Alan Shaw
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "alanshaw"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Mike Goelzer
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "mgoelzer"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Steven Allen
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "stebalien"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Will Scott
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "willscott"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Kadir Topal
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "atopal"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Jacob Heun
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "jacobheun"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: David Choi
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "dchoi27"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Jonathan Victor
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "jnthnvctr"
+        token: ${{ secrets.GITHUB_TOKEN }}  
+    - name: Raul Kripalani
+      uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      with:
+        reviewers: "raulk"
+        token: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -50,7 +50,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}  
     - name: Alan Shaw
       uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
-      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      if: contains(fromJSON('["hugomrdias","gozala","ribasushi","jnthnvctr"]'), github.event.pull_request.user.login)
       with:
         reviewers: "alanshaw"
         token: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -14,7 +14,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Rod Vagg
       uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
-      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      if: contains(fromJSON('["achingbrain","vasco-santos","dirkmc"]'), github.event.pull_request.user.login)
       with:
         reviewers: "rvagg"
         token: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -98,7 +98,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}  
     - name: Raul Kripalani
       uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
-      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      if: contains(fromJSON('["nonsense", "kubuxu", "dirkmc", "vyzo", "aarshkshah1992"]'), github.event.pull_request.user.login)
       with:
         reviewers: "raulk"
         token: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -44,7 +44,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}  
     - name: Steve Loeppky
       uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
-      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      if: contains(fromJSON('["arajasek ","aschmahmann ","lidel","magic6k","marten-seemann","schomatis ","stebalien","warpfork","ZenGround0"]'), github.event.pull_request.user.login)
       with:
         reviewers: "BigLep"
         token: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -68,7 +68,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}  
     - name: Will Scott
       uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
-      if: contains(fromJSON('[]'), github.event.pull_request.user.login)
+      if: contains(fromJSON('["acruikshank","hannahhoward","gammazero","mvdan"]'), github.event.pull_request.user.login)
       with:
         reviewers: "willscott"
         token: ${{ secrets.GITHUB_TOKEN }}  


### PR DESCRIPTION
This automation adds specific reviewers to new PR’s.

Right now it’s based on who the submitter is so that team leads and EM’s can subscribe to proposals from their reports, but if we add a consistent tagging system or have some other way of categorizing PR’s we can use that data to automatically add reviewers as well.

@rvagg @momack2 @anorth @pooja @olizilla @BigLep @alanshaw @mgoelzer @Stebalien @willscott @atopal @jacobheun @dchoi27 @raulk leave a comment letting me know who everyone you’d like to “follow” since I don’t have an official list of who reports to whom yet. I’ll add them all in before the PR is merged.