### PR TITLE
Process: Project Pipeline

### DIFF
--- a/.github/workflows/add-to-pipeline.yml
+++ b/.github/workflows/add-to-pipeline.yml
@@ -1,0 +1,15 @@
+name: Add new pull requests to Project Pipeline
+
+on:
+  pull_request:
+    types: [created]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.3.0
+        with:
+          project: Project Pipeline
+          column: Needs Review
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ There are two pipelines for triaging projects. The first is the "Project Pipelin
 Proposals are managed in a Project board with the following columns.
 
 * Needs Review
-* Needs Assign
-* Assigned
+* Needs Owner
+* In Progres
 
-As new proposals are created they are assigned reviewers. Once the required number of reviewers have approved the proposal it will automatically move from the "Needs Review" column to the "Needs Assign" column. Every Monday the project leads will review pending proposals and decide if they should be:
+As new proposals are created they are assigned reviewers. Once the required number of reviewers have approved the proposal it will automatically move from the "Needs Review" column to the "Needs Owner" column. Every Monday the project leads will review pending proposals and decide if they should be:
 
 * Closed. Any proposal that is not something we can assign resources or grant/contract funding.
-* Approved. The card on the project board will be moved to "Assigned" and the PR will be assigned to the Project Team Lead and Engineering Manager. When the project is finished the PR will be merged.
-* Moved to the "Grant Pipeline"
+* Approved. The card on the project board will be moved to "In Progress" and the PR will be assigned to the Project Team Lead and Engineering Manager. When the project is finished the PR will be merged.
+* Moved to the "Help Wanted"
 
-Proposals in the grant pipeline need to be modified to include any associated funding and points of contact. The full Grant Pipeline approval process is TBD.
+Proposals in the "Help Wanted" pipeline need to be modified to include any associated funding and points of contact. The full Help Wanted approval process is TBD.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,21 @@
 This repo is the project management hub for PL's efforts contributing to the Web3 ecosystem through improvements to libp2p, IPFS, IPLD, Filecoin and other projects.
 
 The primary planning mechanism is discussion of proposals for significant projects to be undertaken by PL-sponsored project teams. Check them out on the [projects board](https://github.com/protocol/web3-dev-team/projects/1). Pitch a new project by [filing an issue](https://github.com/protocol/web3-dev-team/issues/new/choose) using the project proposal template.
+
+# Pipelines
+
+There are two pipelines for triaging projects. The first is the "Project Pipeline" which is where all new proposals are reviewed and triaged. A project will either be closed, approved and assigned to a team, or it will be moved to the "Grant Pipeline."
+
+Proposals are managed in a Project board with the following columns.
+
+* Needs Review
+* Needs Assign
+* Assigned
+
+As new proposals are created they are assigned reviewers. Once the required number of reviewers have approved the proposal it will automatically move from the "Needs Review" column to the "Needs Assign" column. Every Monday the project leads will review pending proposals and decide if they should be:
+
+* Closed. Any proposal that is not something we can assign resources or grant/contract funding.
+* Approved. The card on the project board will be moved to "Assigned" and the PR will be assigned to the Project Team Lead and Engineering Manager. When the project is finished the PR will be merged.
+* Moved to the "Grant Pipeline"
+
+Proposals in the grant pipeline need to be modified to include any associated funding and points of contact. The full Grant Pipeline approval process is TBD.


### PR DESCRIPTION
This is a proposal for a lightweight review and triage for project proposals.

The bulk of the work is managed in a single Project Board called “Project Pipeline” (I’ve held off on creating the board until I get some feedback on this proposal).

Here’s a breakdown of the workflow:

* PR Created
* GitHub Action adds any new PR to the “Project Pipeline” board in the “Needs Review” column.
* GitHub Action automatically assigns some reviewers, other reviewers can be added manually by anyone with repo permissions.
* Once the required number of review approvals have been met (configurable in the repo) the card for the PR will automatically move to “Needs Assign.”
* In the weekly leads meeting we can pull up the list of “Needs Assign” and decide whether or not to approve them (note: I called this “Assign” rather than “Approve” because there is already UI in GitHub that calls out PR’s as being “Approved” after they reach the required number of reviewers so I’m staying away from using that term in our flow to avoid confusion)
* A proposal is either closed, moved to the “Assign” column and assigned to a team, or it is moved to the “Grant Pipeline” project board.

I’m leaving the Grant Pipeline process TBD for the moment, but the idea here is to leverage the work we’ve already done in scoping and defining these proposals into potential grants and contracts.

There are still some details to work out, like how many proposals do we assign to each team, how are teams prioritizing the approved projects, etc. We may need some kind of “backlog” here but my preference would be to push anything we can’t do immediately into the grant pipeline and then pull them back off if/when a team is free or the priority we’d like to assign to a proposal changes.

Something nice about this flow is that there isn’t much manual intervention and the manual work we are committing to is part of a weekly process we can put a recurring meeting on. 