### PR TITLE
template: improve the confidence section

### DIFF
--- a/proposals/TEMPLATE.md
+++ b/proposals/TEMPLATE.md
@@ -51,7 +51,7 @@ Explain the opportunity or leverage point for our subsequent velocity/impact (e.
 -->
 
 #### Confidence
-_How sure are we that this impact would be realized? Label from [this scale](https://medium.com/@nimay/inside-product-introduction-to-feature-priority-using-ice-impact-confidence-ease-and-gist-5180434e5b15)_.
+_How sure are we that this is the right problem to work on? Label from [this scale](https://medium.com/@nimay/inside-product-introduction-to-feature-priority-using-ice-impact-confidence-ease-and-gist-5180434e5b15)_.
 
 <!--Explain why this rating-->
 


### PR DESCRIPTION
Currently, it asks:

> How sure are we that this impact will be realized?

Where "impact" is:

> How would this directly contribute to web3 dev stack product-market fit?

I read this as:

> How sure are we that this project will successfully achieve the
"impact" specified in the impact section?

However, I don't believe this was the intended question. The intention was to determine how confident we are that we're solving the _right_ problem, not how confident we are that the proposal will solve the problem.

I've changed the template to ask:

> How sure are we that this is the right problem to work on?